### PR TITLE
Clean up album detection, remove redundancy

### DIFF
--- a/audius-dl.py
+++ b/audius-dl.py
@@ -81,8 +81,7 @@ def resolve_link(link, endpoint):
 			headers = {
 				'Accept': 'text/plain'
 			}
-			if link[-1] == '/':
-				link = link[:-1]
+			
 			r = requests.get(f'{endpoint}/v1/resolve', params = { 'url': link }, headers = headers)
 
 			if r.status_code == 200:
@@ -437,17 +436,13 @@ def main():
 		link = input("Please enter a link: ")
 	else:
 		link = sys.argv[1]
-
-	if '/album/' in link:
-		download_album(link)
-		exit()
-
-	elif '/playlist/' in link:
-		download_album(link)
-		exit()
-
+	
 	if link[-1] == '/':
 		link = link[:-1]
+
+	if any(s in link for s in ('/album/', '/playlist/')):
+		download_album(link)
+		exit()
 
 	if link.split('audius.co')[1].count('/') == 1:
 		if '--deleted' in sys.argv:
@@ -455,12 +450,9 @@ def main():
 		else:
 			download_profile(link)
 		exit()
-
-	elif link.split('audius.co')[1].count('/') == 2:
+	else:
 		download_single_track_from_permalink(link)
 		exit()
-
-
 
 if __name__ == '__main__':
 	base_path = os.getcwd()

--- a/audius-dl.py
+++ b/audius-dl.py
@@ -94,6 +94,7 @@ def resolve_link(link, endpoint):
 		except:
 			print("An exception occurred while trying to resolve the link, trying again in two seconds...")
 			time.sleep(2)
+
 def get_permalink_for_track(id):
 	r = requests.get(f'https://audius.co/tracks/{id}')
 	return r.url
@@ -355,7 +356,12 @@ def download_album(link):
 
 	res = resolve_link(link, endpoint)
 	j = json.loads(res)
-	user_id = j['data'][0]['user']['id']
+	try:
+		# Catch specifically-crafted inputs
+		user_id = j["data"][0]["user"]["id"]
+	except:
+		print("Enter a valid URL.")
+		exit()
 	album_id = j['data'][0]['id']
 	album_name = j['data'][0]['playlist_name']
 


### PR DESCRIPTION
Planned to clean this up for a bit now, got around to making a PR.

This commit:
- Changes how audius-dl detects albums and playlists using the `any()` function
- Removes redundancy in removing the / symbol at the end of URLs
- Catch specifically-crafted inputs (such as "/album/") instead of throwing an error

I also think updating hashids.py to match the current version at [https://github.com/davidaurelio/hashids-python/blob/master/hashids.py](davidaurelio/hashids-python) would be a good idea - I believe it's just performance improvements - but I don't have a deleted track on Audius to test it out on.